### PR TITLE
Fix for 2 minor bugs

### DIFF
--- a/js/globals.js
+++ b/js/globals.js
@@ -1,0 +1,11 @@
+if (!window.scout) {
+
+  window.scout = {
+    clickHandler: function(event) {
+      if (event.type === 'click') {
+        event.stopPropagation();
+      }
+    }
+  }
+
+}

--- a/js/hide.js
+++ b/js/hide.js
@@ -3,5 +3,10 @@ var labelContainers = document.querySelectorAll('.scout-qa--label-wrap');
 
 targets.forEach(target => target.classList.remove('scout-qa--highlight'));
 
-labelContainers.forEach(container => container.remove());
+labelContainers.forEach(container => {
+    if (window.scout) {
+      container.removeEventListener('click', window.scout.clickHandler);
+    }
+    container.remove();
+});
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -18,6 +18,10 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  chrome.tabs.executeScript({ 
+    file: 'js/globals.js'
+  });
+
   function show () {
     // Remove any residual elements
     storage.remove('scoutHighlight');

--- a/js/show.js
+++ b/js/show.js
@@ -3,24 +3,28 @@ var description = document.querySelector('.scout-qa--description');
 var targets = Array.from(document.querySelectorAll('[data-test]'));
 
 targets.forEach(target => {
-  const container = document.createElement('div');
-  const valueWrap = document.createElement('div');
-  const labelWrap = document.createElement('div');
+  const existingContainer = target.querySelector('.scout-qa--label-wrap');
 
-  const label = document.createTextNode('data-test');
-  const value = target.dataset.test;
-
-  container.classList.add('scout-qa--label-wrap');
-  container.append(labelWrap);
-  container.append(valueWrap);
-
-  labelWrap.append(label);
-  valueWrap.append(value);
-
-  labelWrap.classList.add('scout-qa--label');
-  valueWrap.classList.add('scout-qa--value');
+  if (!existingContainer) {
+    const container = document.createElement('div');
+    const valueWrap = document.createElement('div');
+    const labelWrap = document.createElement('div');
   
-  target.append(container);
-  target.classList.add('scout-qa--highlight');
+    const label = document.createTextNode('data-test');
+    const value = target.dataset.test;
+  
+    container.classList.add('scout-qa--label-wrap');
+    container.append(labelWrap);
+    container.append(valueWrap);
+  
+    labelWrap.append(label);
+    valueWrap.append(value);
+  
+    labelWrap.classList.add('scout-qa--label');
+    valueWrap.classList.add('scout-qa--value');
+    
+    target.append(container);
+    target.classList.add('scout-qa--highlight');
+  }
 });
 

--- a/js/show.js
+++ b/js/show.js
@@ -16,6 +16,9 @@ targets.forEach(target => {
     container.classList.add('scout-qa--label-wrap');
     container.append(labelWrap);
     container.append(valueWrap);
+    if (window.scout) {
+      container.addEventListener('click', window.scout.clickHandler);
+    }
   
     labelWrap.append(label);
     valueWrap.append(value);


### PR DESCRIPTION
This PR will fix the 2 minor bugs listed below.

#### Opening the scout popup multiple times having the checkbox enabled would lead to multiple scout elements in the DOM.
This was fixed by:
+ Adding a guard to only add scout elements if the current target doesn't have them.

#### Clicking on a scout element would trigger click events for their parent elements, making it difficult to copy a data-test value. 
This was fixed by:
+ Adding an event listener to all scout containers to handle the click event
+ Removing this event listener when removing the element from the DOM.
+ Adding a `globals.js` file to keep a single function reference for the event handlers.

Notes:
We might want to increase the version number to `1.2`.